### PR TITLE
feat: Add Botkube

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Container Images Mirror 
+# Container Images Mirror
 
 Images are hosted on Github Container Registry [here](https://github.com/orgs/k8s-at-home/packages?ecosystem=container&visibility=public).
 
@@ -21,6 +21,7 @@ When upstream maintainers add support for an additional registry, the images her
 | [prometheus-qbittorrent-exporter](https://github.com/esanchezm/prometheus-qbittorrent-exporter) | [![GitHub issue status](https://img.shields.io/github/issues/detail/state/esanchezm/prometheus-qbittorrent-exporter/12)](https://github.com/esanchezm/prometheus-qbittorrent-exporter/issues/12)   |
 | [traefik](https://github.com/traefik/traefik)                                                | [![GitHub issue status](https://img.shields.io/github/issues/detail/state/traefik/traefik/8149)](https://github.com/traefik/traefik/issues/8149)                                                 |
 | [unpoller](https://github.com/unpoller/unpoller)                                                | [![GitHub issue status](https://img.shields.io/github/issues/detail/state/unpoller/unpoller/368)](https://github.com/unpoller/unpoller/issues/368)                                                 |
+| [botkube](https://github.com/infracloudio/botkube)                                                | [![GitHub issue status](https://img.shields.io/github/issues/detail/state/infracloudio/botkube/446)](https://github.com/infracloudio/botkube/issues/446)                                    |
 
 ## Contributing
 

--- a/apps/botkube/Dockerfile
+++ b/apps/botkube/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.io/raspbernetes/botkube:v0.12.1
+
+LABEL "org.opencontainers.image.source"="https://github.com/k8s-at-home/container-images-mirror"

--- a/apps/botkube/PLATFORM
+++ b/apps/botkube/PLATFORM
@@ -1,0 +1,1 @@
+linux/amd64,linux/arm/v7,inux/arm64


### PR DESCRIPTION
Description of the change

Add Botkube container to mirror

Benefits

No more rate-limited re-building of cluster, and it has more architectures supported.